### PR TITLE
Added 'type:' before "web mapping applications" in the search filter.

### DIFF
--- a/src/ArcGISPortalViewer/Model/SearchService.cs
+++ b/src/ArcGISPortalViewer/Model/SearchService.cs
@@ -12,7 +12,7 @@ namespace ArcGISPortalViewer.Model
     {
         public static SearchParameters CreateSearchParameters(string searchText, PortalQuery portalQuery, int startIndex = 1, int limit = 20, IList<string> favoriteItemIDs = null)
         {
-            string queryString = string.Format("{0} ({1})", searchText, "type:\"web map\" NOT \"web mapping application\"");            
+            string queryString = string.Format("{0} ({1})", searchText, "type:\"web map\" NOT type:\"web mapping application\"");            
             string sortField = "";
             QuerySortOrder sortOrder = QuerySortOrder.Descending;
 


### PR DESCRIPTION
Although it was not of type "web mapping applications", the "national geographic" featured map had the phrase "web mapping applications" in its snippet (see snapshot below), that is why it was filtered out.

![4-22-2014 11-41-03 am](https://cloud.githubusercontent.com/assets/3813516/2769424/54668dc0-ca51-11e3-938f-fd0eea1fa175.png)

Resolves issue #16
@dotMorten for code review.
@rexhansen  for QA.
