### PR TITLE
Jenn6286/issue15 measure display scrollbar items control

### DIFF
--- a/src/ArcGISPortalViewer/Controls/MeasureDisplayControl.xaml
+++ b/src/ArcGISPortalViewer/Controls/MeasureDisplayControl.xaml
@@ -17,28 +17,30 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Text="Measure"
                    Style="{StaticResource PageSubheaderTextStyle}"
                    Margin="0,0,0,10" />
-        <Grid Grid.Row="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <TextBlock Text="Tap the map to add a measure point"
+            <TextBlock Grid.Row="1"
+                Text="Tap the map to add a measure point"
                        Style="{StaticResource ItemTextStyle}" />
-            <ScrollViewer Grid.Row="1"
-                          ZoomMode="Disabled"
-                          Padding="0,10,20,0"
-                          Margin="0,0,-20,0"
-                          FontSize="14">
-                <ItemsControl x:Name="MeasureItems">
-                    <ItemsControl.ItemTemplate>
+                <ItemsControl x:Name="MeasureItems"
+                          Grid.Row="2"
+                          FontSize="14"
+                          ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <ItemsControl.Template>
+                    <ControlTemplate>
+                        <ScrollViewer ZoomMode="Disabled"
+                                      Padding="0,10,20,0"
+                                      Margin="0,0,-20,0">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </ControlTemplate>
+                </ItemsControl.Template>
+                <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Grid Margin="0,0,0,5"
                                   IsHoldingEnabled="True"
@@ -65,9 +67,8 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-            </ScrollViewer>
             <Grid x:Name="ResultSummary"
-                  Grid.Row="2">
+                  Grid.Row="3">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -100,11 +101,10 @@
                                Style="{StaticResource ItemTextStyle}" />
                 </Grid>
             </Grid>
-            <Button Grid.Row="3"
+            <Button Grid.Row="4"
                     Content="Reset"
                     HorizontalAlignment="Right"
                     Click="ResetMeasure_Click"
                     Margin="0,20,0,20" />
-        </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
This resolves #15 

@hmassih  : Please code-review

Branch was created from v.next with change to MeasureDisplayControl.xaml only.

Changes:
- Removed inner grid that takes row height=auto because this allowed grid to grow without height restriction. 
- Removed ScrollViewer that contained ItemsControl because this is ignored by ItemsControl and set its ControlTemplate to surround ItemsPresenter with ScrollViewer instead.
